### PR TITLE
Huffman encoder/decoder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bit-vec = "0.6.3"
+bitstream-rs = "0.2.0"
 huffman-coding = "0.1.2"
 indicatif = "0.17.7"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# naive compression experiments using enwik9
+
+This is a testbed for me learning stuff about compression techniques, motivated by enwik9, although only compression ratios down to zip-like tools are approximately reached with far too large time and memory complexity..
+
+current lowest size for the first 1 MB is ~317 kB using prepd>probcodes>huffman path (no run-length encoding).

--- a/src/huffman.rs
+++ b/src/huffman.rs
@@ -114,11 +114,11 @@ impl<X> HuffmanNode<X> {
         }
     }
 
-    fn from_bitnode<R>(br: &mut BitReader<R, NoPadding>, readnleaf: usize) -> Option<(Self, &mut BitReader<R, NoPadding>)> where X: SerializedBits, R: std::io::Read {
+    fn from_bitnode<R>(br: &mut BitReader<R, NoPadding>) -> Option<(Self, &mut BitReader<R, NoPadding>)> where X: SerializedBits, R: std::io::Read {
         match br.next() {
             Some(true) => {
                 let mut bv = BitVec::new();
-                for _ in 0..readnleaf {
+                for _ in 0..X::bitlen() {
                     match br.next() {
                         Some(bit) => bv.push(bit),
                         None => return None
@@ -128,16 +128,16 @@ impl<X> HuffmanNode<X> {
                 Some(( Self {weight: 0, node_type: NodeType::Leaf(symbol)}, br ))
             }
             Some(false) => {
-                let x = Self::from_bits(br, readnleaf)?;
+                let x = Self::from_bits(br)?;
                 Some(x)
             }
             None => None
         }
     }
 
-    fn from_bits<R>(br: &mut BitReader<R, NoPadding>, readnleaf: usize) -> Option<(Self, &mut BitReader<R, NoPadding>)> where X: SerializedBits, R: std::io::Read {
-        let (node_a, ba) = Self::from_bitnode(br, readnleaf)?;
-        let (node_b, bb) = Self::from_bitnode(ba, readnleaf)?;
+    fn from_bits<R>(br: &mut BitReader<R, NoPadding>) -> Option<(Self, &mut BitReader<R, NoPadding>)> where X: SerializedBits, R: std::io::Read {
+        let (node_a, ba) = Self::from_bitnode(br)?;
+        let (node_b, bb) = Self::from_bitnode(ba)?;
         Some(( Self {weight: 0, node_type: NodeType::Internal(Box::new(node_a), Box::new(node_b))}, bb ))
     }
 
@@ -156,7 +156,7 @@ impl<X> HuffmanNode<X> {
         let file = File::open(filename)?;
         let mut br = BitReader::new(&file);
 
-        let (hufftree, _) = Self::from_bits(&mut br, X::bitlen()).unwrap();
+        let (hufftree, _) = Self::from_bits(&mut br).unwrap();
         Ok( hufftree )
     }
 }

--- a/src/huffman.rs
+++ b/src/huffman.rs
@@ -83,7 +83,7 @@ impl<X> HuffmanNode<X> {
         }
     }
 
-    pub fn to_dictionary(self) -> EncodeDict<X> where X: Eq, X: Hash {
+    pub fn encoding_dictionary(self) -> EncodeDict<X> where X: Eq, X: Hash {
         gen_entries(self, BitVec::new())
     }
 
@@ -161,20 +161,20 @@ impl<X> HuffmanNode<X> {
     }
 }
 
-pub fn count_freqs<X>(contents: X) -> HashMap<X::Item, usize> where X: Iterator, X::Item: Eq, X::Item: Hash {
+pub fn count_freqs<I>(input: I) -> HashMap<I::Item, usize> where I: Iterator, I::Item: Eq, I::Item: Hash {
     let mut counters = HashMap::new();
-    for symbol in contents {
+    for symbol in input {
         let location = counters.entry(symbol).or_insert(0);
         *location += 1;
     }
     counters
 }
 
-pub fn encode<X>(input: &[X], dic: EncodeDict<X>) -> Vec<u8> where X: Eq, X: PartialEq, X: Hash {
+pub fn encode<I>(input: I, dic: EncodeDict<I::Item>) -> Vec<u8> where I: Iterator, I::Item: Eq, I::Item: PartialEq, I::Item: Hash {
     let mut encoded: Vec<u8> = Vec::new();
     let mut bw = BitWriter::new(&mut encoded);
     for symbol in input {
-        let code = dic.get(symbol).expect("symbol should be in dictionary");
+        let code = dic.get(&symbol).expect("symbol should be in dictionary");
         for bit in code {
             bw.write_bit(bit).unwrap();
         }

--- a/src/huffman.rs
+++ b/src/huffman.rs
@@ -1,0 +1,71 @@
+use std::collections::HashMap;
+use std::cmp::Reverse;
+use bit_vec::BitVec;
+use bitstream::BitWriter;
+
+enum NodeType {
+    Internal (Box<HuffmanNode>, Box<HuffmanNode>),
+    Leaf(usize)
+}
+
+pub struct HuffmanNode {
+    pub weight: usize,
+    node_type: NodeType
+}
+
+impl HuffmanNode {
+    pub fn new(a: HuffmanNode, b: HuffmanNode) -> Self {
+        Self { weight: a.weight + b.weight , node_type: NodeType::Internal(Box::new(a), Box::new(b))}
+    }
+}
+
+pub fn huffman_code(weights: &[usize]) -> HuffmanNode {
+    let symbols: Vec<usize> = (0..weights.len()).filter(|&w| w!=0).collect();
+
+    let mut nodes: Vec<HuffmanNode> = symbols.into_iter().map(|sym| HuffmanNode { weight: weights[sym], node_type: NodeType::Leaf(sym) }).collect();
+    loop {
+        nodes.sort_by_key(|f| Reverse(f.weight));
+        let a = nodes.pop().unwrap();
+        let b = nodes.pop().unwrap();
+        let new_node = HuffmanNode::new(a, b);
+        if nodes.is_empty() {
+            return new_node;
+        }
+        nodes.push(new_node);
+    }
+}
+
+type HuffDict = HashMap<usize, BitVec>;
+
+fn gen_entries(node: HuffmanNode, prefix: BitVec) -> HuffDict {
+    let mut dic: HuffDict = HashMap::new();
+    match node.node_type {
+        NodeType::Leaf(sym) => { dic.insert(sym, prefix); dic }
+        NodeType::Internal(node_a, node_b) => {
+            let mut prefix_a = prefix.clone();
+            prefix_a.push(false);
+            dic.extend( gen_entries(*node_a, prefix_a) );
+            let mut prefix_b = prefix.clone();
+            prefix_b.push(true);
+            dic.extend( gen_entries(*node_b, prefix_b) );
+            dic
+        }
+    }
+}
+
+pub fn gen_dictionary(root_node: HuffmanNode) -> HuffDict {
+    gen_entries(root_node, BitVec::new())
+}
+
+pub fn encode(input: &[usize], dic: HuffDict) -> Vec<u8> {
+    let mut encoded: Vec<u8> = Vec::new();
+    let mut bw = BitWriter::new(&mut encoded);
+    for symbol in input {
+        let code = dic.get(symbol).expect("symbol should be in dictionary");
+        for bit in code {
+            bw.write_bit(bit).unwrap();
+        }
+    }
+    drop(bw);
+    encoded
+}

--- a/src/huffman.rs
+++ b/src/huffman.rs
@@ -20,9 +20,9 @@ impl HuffmanNode {
 }
 
 pub fn huffman_code(weights: &[usize]) -> HuffmanNode {
-    let symbols: Vec<usize> = (0..weights.len()).filter(|&w| w!=0).collect();
+    let occuring_symbols = (0..weights.len()).filter(|&w| w!=0);
 
-    let mut nodes: Vec<HuffmanNode> = symbols.into_iter().map(|sym| HuffmanNode { weight: weights[sym], node_type: NodeType::Leaf(sym) }).collect();
+    let mut nodes: Vec<HuffmanNode> = occuring_symbols.map(|sym| HuffmanNode { weight: weights[sym], node_type: NodeType::Leaf(sym) }).collect();
     loop {
         nodes.sort_by_key(|f| Reverse(f.weight));
         let a = nodes.pop().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,11 @@ use std::env;
 
 use indicatif::{ProgressBar, ProgressStyle};
 
+mod huffman;
+use huffman::{huffman_code, encode};
+
+use crate::huffman::gen_dictionary;
+
 fn bar(total_size: u64) -> ProgressBar { //from indicatif example "download.rs"
     let pb = ProgressBar::new(total_size);
     pb.set_style(ProgressStyle::with_template("{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} ({eta})")
@@ -235,6 +240,17 @@ fn main() -> Result<()> {
             let mut huffcodes = std::fs::File::create(huffbin_file)?;
             let mut writer = HuffmanWriter::new(&mut huffcodes, &tree);
             writer.write(&contents)?;
+            Ok(())
+        }
+        "test-huffencode16bit" => {
+            let freqs: Vec<usize> = (0..16).collect();
+            let hufftree = huffman_code(&freqs);
+            let mydict = gen_dictionary(hufftree);
+            println!("highest symbol number should have shortest code, and zero-freq symbols (0) should not occur:\n{:?}", mydict);
+            let message: Vec<usize> = (1..16).collect();
+            let encoded = encode(&message, mydict);
+            print!("encoded stream:"); // should be regrouped of 000000 000001 00001 11000 11001 .. 011 101 with possible zeros at end
+            let _: Vec<_> = encoded.into_iter().map(|num| print!(" {:08b}", num)).collect();
             Ok(())
         }
         "huffdecode->" => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -259,7 +259,7 @@ fn main() -> Result<()> {
             //let contents = read_u16(filename)?;
 
             let tree = dummy_tree();
-            
+            tree.to_file("tree.test")?;
             let edict = tree.to_dictionary();
             println!("{:?}", edict);
             let message = vec![3,1,4,1,5,9];
@@ -281,7 +281,8 @@ fn main() -> Result<()> {
             write(filename, contents)
         }
         "test:huffdecode16bit" => {
-            let tree = dummy_tree();
+            //let tree = dummy_tree();
+            let tree: HuffmanNode<u16> = HuffmanNode::from_file("tree.test")?;
 
             let encoded = vec![151,87,60];
             let decoded = decode(&encoded, tree);

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use std::env;
 use indicatif::{ProgressBar, ProgressStyle};
 
 mod huffman;
-use huffman::{count_freqs, huffman_code, gen_dictionary, encode, decode, HuffmanNode};
+use huffman::{count_freqs, encode, decode, HuffmanNode};
 
 fn bar(total_size: u64) -> ProgressBar { //from indicatif example "download.rs"
     let pb = ProgressBar::new(total_size);
@@ -136,7 +136,7 @@ fn used_from(unused_symbols: &[u8]) -> Vec<u8> {
 fn dummy_tree() -> HuffmanNode<u16> {
     let contents: Vec<u16> = vec![1,1,2,2,2,6,6,4,3,3,3,3,3,5,7,7,7,7,8,8,9,9];
     let freqs = count_freqs(contents.into_iter());
-    huffman_code(freqs)
+    HuffmanNode::from_weights(freqs)
 }
 
 fn main() -> Result<()> {
@@ -260,8 +260,8 @@ fn main() -> Result<()> {
 
             let tree = dummy_tree();
             
-            let edict = gen_dictionary(tree);
-            println!("highest symbol number should have shortest code, and zero-freq symbols (0) should not occur:\n{:?}", edict);
+            let edict = tree.to_dictionary();
+            println!("{:?}", edict);
             let message = vec![3,1,4,1,5,9];
             let encoded = encode(&message, edict);
             print!("encoded stream:");

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,9 +8,7 @@ use std::env;
 use indicatif::{ProgressBar, ProgressStyle};
 
 mod huffman;
-use huffman::{huffman_code, encode};
-
-use crate::huffman::gen_dictionary;
+use huffman::{huffman_code, gen_dictionary, encode, decode as h16decode};
 
 fn bar(total_size: u64) -> ProgressBar { //from indicatif example "download.rs"
     let pb = ProgressBar::new(total_size);
@@ -244,13 +242,14 @@ fn main() -> Result<()> {
         }
         "test-huffencode16bit" => {
             let freqs: Vec<usize> = (0..16).collect();
-            let hufftree = huffman_code(&freqs);
-            let mydict = gen_dictionary(hufftree);
-            println!("highest symbol number should have shortest code, and zero-freq symbols (0) should not occur:\n{:?}", mydict);
-            let message: Vec<usize> = (1..16).collect();
-            let encoded = encode(&message, mydict);
-            print!("encoded stream:"); // should be regrouped of 000000 000001 00001 11000 11001 .. 011 101 with possible zeros at end
-            let _: Vec<_> = encoded.into_iter().map(|num| print!(" {:08b}", num)).collect();
+            let tree = huffman_code(&freqs);
+            
+            let edict = gen_dictionary(tree);
+            println!("highest symbol number should have shortest code, and zero-freq symbols (0) should not occur:\n{:?}", edict);
+            let message: Vec<usize> = vec![3,1,4,1,5,9];
+            let encoded = encode(&message, edict);
+            print!("encoded stream:");
+            let _: Vec<_> = encoded.into_iter().map(|num| print!(" {:08b}({})", num, num)).collect();
             Ok(())
         }
         "huffdecode->" => {
@@ -264,7 +263,16 @@ fn main() -> Result<()> {
             let mut contents: Vec<u8> = Vec::new();
             reader.read_to_end(&mut contents)?;
             write(filename, contents)
-        }  
+        }
+        "test-huffdecode16bit" => {
+            let freqs: Vec<usize> = (0..16).collect();
+            let tree = huffman_code(&freqs);
+
+            let encoded = vec![8,24,3,58];
+            let decoded = h16decode(&encoded, tree);
+            println!("decoded {:?}", decoded);
+            Ok(())
+        }
         "rldecode->" => {
             let filename = args.next().unwrap();
 


### PR DESCRIPTION
this adds a new huffman encoder/decoder that is not limited to a specific symbol type. it originated from the wish to use run-length encoding. by using this encoder, the small advantage of using run-length encoding before huffman coding vanished.