### PR TITLE
Content trickery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # naive compression experiments using enwik9
 
-This is a testbed for me learning stuff about compression techniques, motivated by enwik9, although only compression ratios down to zip-like tools are approximately reached with far too large time and memory complexity..
+This is a testbed for me learning stuff about compression techniques, motivated by enwik9, although only compression ratios down to zip-like tools are approximately reached with far too large time and memory complexity.
 
-current lowest size for the first 1 MB is ~320 kB using prepd>probcodes>huffman path (no run-length encoding).
+current sizes for the first 1_000_000 bytes (files without exe):
+
+| encoding Path                        | files    |    size |
+| ------------------------------------ | -------- | ------- |
+| prepd(v2)-probcodes-rle-huffencode16 | tree,bin | 303_897 |
+| prepd(v2)-probcodes-huffencode8      |          | 315_739 |
+| prepd(v0)-probcodes-huffencode8      |          | 319_217 |
+| prepd(v0)-probcodes-huffencode16     |          | 319_990 |

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,6 @@ fn main() -> Result<()> {
             file.truncate(max_len);
 
             let unused = read(UNUSED_FILE)?;
-
             let xml_end = unused[0]; // used for v1
             let big_char = unused[1]; //used for v1+v2
 
@@ -312,6 +311,34 @@ fn main() -> Result<()> {
             let probcodes = read(probcodes_file_d)?;
             let prepd = prob_decode(&probcodes);
             write(filename, prepd)
+        }
+        "unprep_incomplete->" => {
+            let filename = args.next().unwrap();
+
+            let mut prepd = read(prepd_file.to_owned()+".d")?;
+            prepd.reverse(); 
+            
+            let unused = read(UNUSED_FILE)?;
+            //let xml_end = unused[0]; // used for v1
+            let big_char = unused[1]; //used for v1+v2
+
+            let mut out: Vec<u8> = Vec::with_capacity(prepd.len());
+
+            let mut n = 0;
+            loop {
+                let ch = prepd[n];
+
+                let to_push =
+                if ch == big_char {
+                    n += 1; prepd[n]-32 //.to_uppercase
+                } else {
+                    ch
+                }; 
+                out.push(to_push);
+                n += 1;
+                if n>=prepd.len() { break; }
+            }
+            write(filename, out)
         }
         x => Err( Error::new(ErrorKind::NotFound, format!("unknown mode {x}")) )
     }


### PR DESCRIPTION
Added
- a runlength encoder using 8-bit pairs
- content preparation by exploiting structure of enwik input document and separate "shift" symbol ("trickery")
- overview in readme for compressed filesizes